### PR TITLE
Fix blog url

### DIFF
--- a/src/pages/user/Sidebar.js
+++ b/src/pages/user/Sidebar.js
@@ -7,9 +7,13 @@ import StatisticsBox from './../../components/main/StatisticsBox';
 export default class Sidebar extends Component {
   userSite({ blog, name }) {
     if (blog) {
+      const containProtocol = blog.indexOf("http://") === 0 || blog.indexOf("https://") === 0;
+      if(!containProtocol) {
+        blog = 'http://' + blog;        
+      }
       return (
         <div>
-          <a href={`http://${blog}`} target="_blank" id="user-site">
+          <a href={blog} target="_blank" id="user-site">
             <img src={svgLink} alt={`${name} website`} />
           </a>
         </div>


### PR DESCRIPTION
Because the link to my blog (web page) did not work I started to investigate a little and I noticed that the github api when asked for the user's `blog` attribute, sometimes does not add the protocol in the url either for http or https, so I added a small piece of code that resolves the url.